### PR TITLE
Ensure Colectica endpoint returns JSON payload

### DIFF
--- a/module-bauhaus-bo/pom.xml
+++ b/module-bauhaus-bo/pom.xml
@@ -17,6 +17,11 @@
       <artifactId>module-domain</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>fr.insee.ddi</groupId>
+      <artifactId>ddi-lifecycle</artifactId>
+      <version>1.1.0</version>
+    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/config/colectica/ColecticaRepositoryProperties.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/config/colectica/ColecticaRepositoryProperties.java
@@ -1,0 +1,89 @@
+package fr.insee.rmes.config.colectica;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.net.URI;
+import java.time.Duration;
+
+@Validated
+@ConfigurationProperties(prefix = "fr.insee.rmes.bauhaus.colectica")
+public class ColecticaRepositoryProperties {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+
+    @NotNull
+    private URI baseUrl;
+
+    private Duration connectTimeout = DEFAULT_TIMEOUT;
+
+    private Duration readTimeout = DEFAULT_TIMEOUT;
+
+    @NotBlank
+    private String itemPath = "/Repository/api/items/{itemType}/{agency}/{identifier}/{version}";
+
+    @NotBlank
+    private String latestItemPath = "/Repository/api/items/{itemType}/{agency}/{identifier}/latest";
+
+    private String username;
+
+    private String password;
+
+    public URI getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(URI baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout != null ? connectTimeout : DEFAULT_TIMEOUT;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout != null ? readTimeout : DEFAULT_TIMEOUT;
+    }
+
+    public String getItemPath() {
+        return itemPath;
+    }
+
+    public void setItemPath(String itemPath) {
+        this.itemPath = itemPath;
+    }
+
+    public String getLatestItemPath() {
+        return latestItemPath;
+    }
+
+    public void setLatestItemPath(String latestItemPath) {
+        this.latestItemPath = latestItemPath;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/application/ColecticaConfiguration.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/application/ColecticaConfiguration.java
@@ -1,0 +1,16 @@
+package fr.insee.rmes.onion.application;
+
+import fr.insee.rmes.onion.domain.port.clientside.ColecticaService;
+import fr.insee.rmes.onion.domain.port.serverside.ColecticaRepository;
+import fr.insee.rmes.onion.domain.services.colectica.ColecticaServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ColecticaConfiguration {
+
+    @Bean
+    ColecticaService colecticaService(ColecticaRepository repository) {
+        return new ColecticaServiceImpl(repository);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/application/handler/DomainExceptionHandler.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/application/handler/DomainExceptionHandler.java
@@ -1,6 +1,7 @@
 package fr.insee.rmes.onion.application.handler;
 
 import fr.insee.rmes.onion.domain.exceptions.GenericInternalServerException;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
 import fr.insee.rmes.onion.domain.exceptions.operations.NotFoundAttributeException;
 import fr.insee.rmes.onion.domain.exceptions.operations.OperationDocumentationRubricWithoutRangeException;
 import org.springframework.http.HttpStatus;
@@ -24,5 +25,10 @@ public class DomainExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler({ OperationDocumentationRubricWithoutRangeException.class })
     public final ResponseEntity<String> operationDocumentationRubricWithoutRangeException(OperationDocumentationRubricWithoutRangeException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("At least one attribute don't have range " + exception.getId());
+    }
+
+    @ExceptionHandler({ ColecticaRepositoryException.class })
+    public final ResponseEntity<String> colecticaRepositoryException(ColecticaRepositoryException exception) {
+        return ResponseEntity.status(exception.getStatus()).body(exception.getDetails());
     }
 }

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaItemNotFoundException.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaItemNotFoundException.java
@@ -1,0 +1,14 @@
+package fr.insee.rmes.onion.domain.exceptions.colectica;
+
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import org.springframework.http.HttpStatus;
+
+public class ColecticaItemNotFoundException extends ColecticaRepositoryException {
+
+    public ColecticaItemNotFoundException(ColecticaItemRequest request) {
+        super(HttpStatus.NOT_FOUND.value(),
+                "Colectica item not found",
+                String.format("No item found for agency=%s, identifier=%s, version=%s, itemType=%s",
+                        request.agency(), request.identifier(), request.version(), request.itemType()));
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaRepositoryException.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaRepositoryException.java
@@ -1,0 +1,14 @@
+package fr.insee.rmes.onion.domain.exceptions.colectica;
+
+import fr.insee.rmes.onion.domain.exceptions.RmesException;
+
+public abstract class ColecticaRepositoryException extends RmesException {
+
+    protected ColecticaRepositoryException(int status, String message, String details) {
+        super(status, message, details);
+    }
+
+    protected ColecticaRepositoryException(int status, String message, String details, Throwable cause) {
+        super(status, message, details, cause);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaRepositoryTechnicalException.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/exceptions/colectica/ColecticaRepositoryTechnicalException.java
@@ -1,0 +1,14 @@
+package fr.insee.rmes.onion.domain.exceptions.colectica;
+
+import org.springframework.http.HttpStatus;
+
+public class ColecticaRepositoryTechnicalException extends ColecticaRepositoryException {
+
+    public ColecticaRepositoryTechnicalException(String message, String details) {
+        super(HttpStatus.BAD_GATEWAY.value(), message, details);
+    }
+
+    public ColecticaRepositoryTechnicalException(String message, String details, Throwable cause) {
+        super(HttpStatus.BAD_GATEWAY.value(), message, details, cause);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/model/colectica/ColecticaItem.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/model/colectica/ColecticaItem.java
@@ -1,0 +1,9 @@
+package fr.insee.rmes.onion.domain.model.colectica;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ColecticaItem(ObjectNode metadata, JsonNode ddi) {
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/model/colectica/ColecticaItemRequest.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/model/colectica/ColecticaItemRequest.java
@@ -1,0 +1,31 @@
+package fr.insee.rmes.onion.domain.model.colectica;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+
+public record ColecticaItemRequest(
+        @NotBlank String agency,
+        @NotBlank String identifier,
+        String version,
+        @NotBlank String itemType,
+        @JsonProperty(defaultValue = "false") boolean latestVersion,
+        Map<String, String> queryParameters
+) {
+
+    @JsonCreator
+    public ColecticaItemRequest {
+        queryParameters = CollectionUtils.isEmpty(queryParameters) ? Collections.emptyMap() : Map.copyOf(queryParameters);
+    }
+
+    @AssertTrue(message = "version is required when latestVersion is false")
+    public boolean isVersionPresentWhenRequired() {
+        return latestVersion || StringUtils.hasText(version);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/port/clientside/ColecticaService.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/port/clientside/ColecticaService.java
@@ -1,0 +1,9 @@
+package fr.insee.rmes.onion.domain.port.clientside;
+
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+
+public interface ColecticaService {
+    ColecticaItem getItem(ColecticaItemRequest request) throws ColecticaRepositoryException;
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/port/serverside/ColecticaRepository.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/port/serverside/ColecticaRepository.java
@@ -1,0 +1,9 @@
+package fr.insee.rmes.onion.domain.port.serverside;
+
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+
+public interface ColecticaRepository {
+    ColecticaItem fetchItem(ColecticaItemRequest request) throws ColecticaRepositoryException;
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/services/colectica/ColecticaServiceImpl.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/domain/services/colectica/ColecticaServiceImpl.java
@@ -1,0 +1,21 @@
+package fr.insee.rmes.onion.domain.services.colectica;
+
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import fr.insee.rmes.onion.domain.port.clientside.ColecticaService;
+import fr.insee.rmes.onion.domain.port.serverside.ColecticaRepository;
+
+public class ColecticaServiceImpl implements ColecticaService {
+
+    private final ColecticaRepository repository;
+
+    public ColecticaServiceImpl(ColecticaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public ColecticaItem getItem(ColecticaItemRequest request) throws ColecticaRepositoryException {
+        return repository.fetchItem(request);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/infrastructure/colectica/ColecticaRestRepository.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/infrastructure/colectica/ColecticaRestRepository.java
@@ -1,0 +1,207 @@
+package fr.insee.rmes.onion.infrastructure.colectica;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import fr.insee.ddi.lifecycle33.instance.DDIInstanceDocument;
+import fr.insee.rmes.config.colectica.ColecticaRepositoryProperties;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaItemNotFoundException;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryTechnicalException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import fr.insee.rmes.onion.domain.port.serverside.ColecticaRepository;
+import org.apache.xmlbeans.XmlException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriTemplate;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+@Repository
+public class ColecticaRestRepository implements ColecticaRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ColecticaRestRepository.class);
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final XmlMapper xmlMapper;
+    private final ColecticaRepositoryProperties properties;
+
+    public ColecticaRestRepository(RestTemplateBuilder restTemplateBuilder,
+                                   ColecticaRepositoryProperties properties,
+                                   ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        this.xmlMapper = new XmlMapper();
+
+        RestTemplateBuilder builder = restTemplateBuilder
+                .setConnectTimeout(properties.getConnectTimeout())
+                .setReadTimeout(properties.getReadTimeout());
+
+        if (StringUtils.hasText(properties.getUsername())) {
+            builder = builder.basicAuthentication(properties.getUsername(), properties.getPassword());
+        }
+
+        this.restTemplate = builder.build();
+    }
+
+    @Override
+    public ColecticaItem fetchItem(ColecticaItemRequest request) throws ColecticaRepositoryException {
+        URI targetUri = buildUri(request);
+        HttpEntity<Void> entity = new HttpEntity<>(createHeaders());
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(targetUri, HttpMethod.GET, entity, String.class);
+            return transformResponse(response.getBody());
+        } catch (HttpStatusCodeException ex) {
+            if (ex.getStatusCode().value() == 404) {
+                throw new ColecticaItemNotFoundException(request);
+            }
+            throw new ColecticaRepositoryTechnicalException("Colectica repository returned an error", ex.getResponseBodyAsString(), ex);
+        }
+    }
+
+    private URI buildUri(ColecticaItemRequest request) {
+        String templatePath = request.latestVersion() ? properties.getLatestItemPath() : properties.getItemPath();
+        UriTemplate template = new UriTemplate(templatePath);
+
+        Map<String, Object> uriVariables = new HashMap<>();
+        uriVariables.put("itemType", request.itemType());
+        uriVariables.put("agency", request.agency());
+        uriVariables.put("identifier", request.identifier());
+        if (!request.latestVersion()) {
+            uriVariables.put("version", request.version());
+        }
+
+        URI path = template.expand(uriVariables);
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUri(properties.getBaseUrl())
+                .path(path.getPath());
+
+        request.queryParameters().forEach(builder::queryParam);
+
+        return builder.build(true).toUri();
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(MediaType.parseMediaTypes(MediaType.APPLICATION_JSON_VALUE));
+        return headers;
+    }
+
+    private ColecticaItem transformResponse(String body) throws ColecticaRepositoryTechnicalException {
+        if (!StringUtils.hasText(body)) {
+            throw new ColecticaRepositoryTechnicalException("Empty Colectica response", "Response body was empty");
+        }
+
+        JsonNode rootNode;
+        try {
+            rootNode = objectMapper.readTree(body);
+        } catch (JsonProcessingException ex) {
+            throw new ColecticaRepositoryTechnicalException("Unable to parse Colectica JSON response", ex.getOriginalMessage(), ex);
+        }
+        if (!rootNode.isObject()) {
+            throw new ColecticaRepositoryTechnicalException("Unexpected Colectica payload", body);
+        }
+
+        ObjectNode metadata = objectMapper.createObjectNode();
+        JsonNode itemNode = null;
+        var fields = rootNode.fields();
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> entry = fields.next();
+            if ("Item".equals(entry.getKey())) {
+                itemNode = entry.getValue();
+            } else {
+                metadata.set(entry.getKey(), entry.getValue());
+            }
+        }
+
+        JsonNode ddiJson = parseDdi(itemNode);
+        return new ColecticaItem(metadata, ddiJson);
+    }
+
+    private JsonNode parseDdi(JsonNode itemNode) throws ColecticaRepositoryTechnicalException {
+        if (itemNode == null || itemNode.isMissingNode() || itemNode.isNull()) {
+            return null;
+        }
+
+        String raw = extractContent(itemNode);
+        if (!StringUtils.hasText(raw)) {
+            return null;
+        }
+
+        String xml = decodeIfNeeded(raw);
+        if (!StringUtils.hasText(xml)) {
+            return null;
+        }
+
+        // Validate XML using the DDI model
+        try {
+            DDIInstanceDocument.Factory.parse(xml);
+        } catch (XmlException ex) {
+            throw new ColecticaRepositoryTechnicalException("Invalid DDI payload returned by Colectica", ex.getMessage(), ex);
+        }
+        try {
+            return xmlMapper.readTree(xml);
+        } catch (JsonProcessingException ex) {
+            throw new ColecticaRepositoryTechnicalException("Unable to transform DDI XML into JSON", ex.getOriginalMessage(), ex);
+        }
+    }
+
+    private String extractContent(JsonNode itemNode) {
+        if (itemNode.isTextual()) {
+            return itemNode.asText();
+        }
+        if (itemNode.has("XmlContent")) {
+            return itemNode.get("XmlContent").asText();
+        }
+        if (itemNode.has("Content")) {
+            return itemNode.get("Content").asText();
+        }
+        if (itemNode.has("Xml")) {
+            return itemNode.get("Xml").asText();
+        }
+        return itemNode.toString();
+    }
+
+    private String decodeIfNeeded(String value) {
+        String trimmed = value == null ? null : value.trim();
+        if (!StringUtils.hasText(trimmed)) {
+            return null;
+        }
+
+        if (trimmed.startsWith("<")) {
+            return value;
+        }
+
+        try {
+            byte[] decoded = Base64.getDecoder().decode(trimmed);
+            String decodedString = new String(decoded, StandardCharsets.UTF_8);
+            if (decodedString.trim().startsWith("<")) {
+                return decodedString;
+            }
+        } catch (IllegalArgumentException ex) {
+            LOGGER.debug("Value is not base64 encoded DDI", ex);
+        }
+
+        return value;
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/infrastructure/webservice/colectica/ColecticaResources.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/onion/infrastructure/webservice/colectica/ColecticaResources.java
@@ -1,0 +1,58 @@
+package fr.insee.rmes.onion.infrastructure.webservice.colectica;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import fr.insee.rmes.onion.domain.port.clientside.ColecticaService;
+import fr.insee.rmes.rbac.HasAccess;
+import fr.insee.rmes.rbac.RBAC;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/colectica")
+@SecurityRequirement(name = "bearerAuth")
+@ConditionalOnExpression("'${fr.insee.rmes.bauhaus.activeModules}'.contains('colectica')")
+public class ColecticaResources {
+
+    private final ColecticaService service;
+    private final ObjectMapper objectMapper;
+
+    public ColecticaResources(ColecticaService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostMapping(value = "/item", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @HasAccess(module = RBAC.Module.EXTERNAL_COLECTICA, privilege = RBAC.Privilege.READ)
+    @Operation(summary = "Fetch an item from the Colectica repository",
+            responses = {@ApiResponse(responseCode = "200", description = "Item retrieved",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(type = "object")))})
+    public ResponseEntity<JsonNode> getItem(@Valid @RequestBody ColecticaItemRequest request)
+            throws ColecticaRepositoryException {
+        ColecticaItem item = service.getItem(request);
+        ObjectNode payload = objectMapper.createObjectNode();
+        if (item.metadata() != null) {
+            payload.set("metadata", item.metadata());
+        }
+        if (item.ddi() != null) {
+            payload.set("ddi", item.ddi());
+        }
+        return ResponseEntity.ok(payload);
+    }
+}

--- a/module-bauhaus-bo/src/main/java/fr/insee/rmes/rbac/RBAC.java
+++ b/module-bauhaus-bo/src/main/java/fr/insee/rmes/rbac/RBAC.java
@@ -20,6 +20,7 @@ public class RBAC {
         DATASET_DATASET,
         DATASET_DISTRIBUTION,
         GEOGRAPHY,
+        EXTERNAL_COLECTICA,
         UNKNOWN,
     }
 

--- a/module-bauhaus-bo/src/main/resources/bauhaus-core.properties
+++ b/module-bauhaus-bo/src/main/resources/bauhaus-core.properties
@@ -44,8 +44,8 @@ fr.insee.rmes.bauhaus.concepts.maxLengthScopeNote = 350
 ###############################
 fr.insee.rmes.bauhaus.classifications.families.graph = codes/nomenclatures
 
-fr.insee.rmes.bauhaus.activeModules = concepts,classifications,operations,structures,codelists,datasets
-fr.insee.rmes.bauhaus.modules = concepts,classifications,operations,structures,codelists,datasets
+fr.insee.rmes.bauhaus.activeModules = concepts,classifications,operations,structures,codelists,datasets,colectica
+fr.insee.rmes.bauhaus.modules = concepts,classifications,operations,structures,codelists,datasets,colectica
 
 ###############################
 #OPERATIONS
@@ -102,6 +102,15 @@ fr.insee.rmes.bauhaus.insee.graph = organisations/insee
 # GEOGRAPHIE (COG)
 ###############################
 fr.insee.rmes.bauhaus.geographie.graph = geo/cog
+
+###############################
+# COLECTICA
+###############################
+fr.insee.rmes.bauhaus.colectica.base-url = http://localhost:8484
+fr.insee.rmes.bauhaus.colectica.connect-timeout = PT10S
+fr.insee.rmes.bauhaus.colectica.read-timeout = PT30S
+fr.insee.rmes.bauhaus.colectica.item-path = /Repository/api/items/{itemType}/{agency}/{identifier}/{version}
+fr.insee.rmes.bauhaus.colectica.latest-item-path = /Repository/api/items/{itemType}/{agency}/{identifier}/latest
 
 ###############################
 # EXTENSIONS

--- a/module-bauhaus-bo/src/main/resources/rbac.yml
+++ b/module-bauhaus-bo/src/main/resources/rbac.yml
@@ -33,6 +33,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -134,6 +136,8 @@ rbac:
         update: ALL
         publish: ALL
         delete: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         create: ALL
         read: ALL
@@ -187,6 +191,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -226,6 +232,8 @@ rbac:
       dataset_distribution:
         read: ALL
       geography:
+        read: ALL
+      external_colectica:
         read: ALL
       codeslist_codeslist:
         read: ALL
@@ -272,6 +280,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -306,6 +316,8 @@ rbac:
       classification_family:
         read: ALL
       geography:
+        read: ALL
+      external_colectica:
         read: ALL
       codeslist_codeslist:
         read: ALL
@@ -347,6 +359,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -386,6 +400,8 @@ rbac:
       dataset_distribution:
         read: ALL
       geography:
+        read: ALL
+      external_colectica:
         read: ALL
       codeslist_codeslist:
         read: ALL
@@ -437,6 +453,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -486,6 +504,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
     Gestionnaire_indicateur_RMESGNCS:
       operation_family:
         read: STAMP
@@ -531,6 +551,8 @@ rbac:
         read: ALL
       geography:
         read: ALL
+      external_colectica:
+        read: ALL
       codeslist_codeslist:
         read: ALL
       codeslist_partialcodeslist:
@@ -575,6 +597,8 @@ rbac:
       classification_series:
         read: ALL
       geography:
+        read: ALL
+      external_colectica:
         read: ALL
       codeslist_codeslist:
         read: ALL

--- a/module-bauhaus-bo/src/test/java/fr/insee/rmes/onion/infrastructure/colectica/ColecticaRestRepositoryTest.java
+++ b/module-bauhaus-bo/src/test/java/fr/insee/rmes/onion/infrastructure/colectica/ColecticaRestRepositoryTest.java
@@ -1,0 +1,81 @@
+package fr.insee.rmes.onion.infrastructure.colectica;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.insee.rmes.config.colectica.ColecticaRepositoryProperties;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class ColecticaRestRepositoryTest {
+
+    private static final String SAMPLE_XML = """
+            <DDIInstance xmlns=\"ddi:instance:3_3\"
+                         xmlns:r=\"ddi:reusable:3_3\"
+                         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+                         xsi:schemaLocation=\"ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd\">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>example-id</r:ID>
+               <r:Version>1</r:Version>
+            </DDIInstance>
+            """;
+
+    private ColecticaRestRepository repository;
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setUp() {
+        ColecticaRepositoryProperties properties = new ColecticaRepositoryProperties();
+        properties.setBaseUrl(URI.create("http://localhost:8089"));
+        properties.setConnectTimeout(Duration.ofSeconds(5));
+        properties.setReadTimeout(Duration.ofSeconds(5));
+
+        repository = new ColecticaRestRepository(new RestTemplateBuilder(), properties, new ObjectMapper());
+        RestTemplate restTemplate = (RestTemplate) Objects.requireNonNull(
+                ReflectionTestUtils.getField(repository, "restTemplate"));
+        server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+    }
+
+    @Test
+    void shouldFetchItemAndConvertDdiXmlToJson() throws ColecticaRepositoryException {
+        String payload = new ObjectMapper().createObjectNode()
+                .put("AgencyId", "fr.insee")
+                .put("Identifier", "example-id")
+                .put("Version", "1")
+                .put("ItemType", "StudyUnit")
+                .put("Item", Base64.getEncoder().encodeToString(SAMPLE_XML.getBytes(StandardCharsets.UTF_8)))
+                .toString();
+
+        server.expect(requestTo("http://localhost:8089/Repository/api/items/StudyUnit/fr.insee/example-id/1"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(payload, MediaType.APPLICATION_JSON));
+
+        ColecticaItemRequest request = new ColecticaItemRequest("fr.insee", "example-id", "1", "StudyUnit", false, Map.of());
+        ColecticaItem item = repository.fetchItem(request);
+
+        assertThat(item.metadata().path("AgencyId").asText()).isEqualTo("fr.insee");
+        assertThat(item.metadata().path("Item").isMissingNode()).isTrue();
+        assertThat(item.ddi()).isNotNull();
+        assertThat(item.ddi().toString()).contains("example-id");
+        server.verify();
+    }
+}

--- a/module-bauhaus-bo/src/test/java/fr/insee/rmes/onion/infrastructure/webservice/colectica/ColecticaResourcesTest.java
+++ b/module-bauhaus-bo/src/test/java/fr/insee/rmes/onion/infrastructure/webservice/colectica/ColecticaResourcesTest.java
@@ -1,0 +1,65 @@
+package fr.insee.rmes.onion.infrastructure.webservice.colectica;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import fr.insee.rmes.onion.domain.exceptions.colectica.ColecticaRepositoryException;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItem;
+import fr.insee.rmes.onion.domain.model.colectica.ColecticaItemRequest;
+import fr.insee.rmes.onion.domain.port.clientside.ColecticaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ColecticaResourcesTest {
+
+    private ColecticaService service;
+    private ObjectMapper objectMapper;
+    private ColecticaResources resources;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(ColecticaService.class);
+        objectMapper = new ObjectMapper();
+        resources = new ColecticaResources(service, objectMapper);
+    }
+
+    @Test
+    void shouldReturnJsonPayloadWithMetadataAndDdi() throws Exception {
+        ObjectNode metadata = objectMapper.createObjectNode().put("AgencyId", "fr.insee");
+        ObjectNode ddi = objectMapper.createObjectNode();
+        ddi.set("DDIInstance", objectMapper.createObjectNode().put("ID", "test"));
+        when(service.getItem(any(ColecticaItemRequest.class))).thenReturn(new ColecticaItem(metadata, ddi));
+
+        ColecticaItemRequest request = new ColecticaItemRequest("fr.insee", "id", "1", "StudyUnit", false, Map.of());
+
+        JsonNode body = resources.getItem(request).getBody();
+
+        assertThat(body).isNotNull();
+        assertThat(body.path("metadata").path("AgencyId").asText()).isEqualTo("fr.insee");
+        assertThat(body.path("ddi").path("DDIInstance").path("ID").asText()).isEqualTo("test");
+
+        ArgumentCaptor<ColecticaItemRequest> captor = ArgumentCaptor.forClass(ColecticaItemRequest.class);
+        verify(service).getItem(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(request);
+    }
+
+    @Test
+    void shouldOmitMissingNodes() throws ColecticaRepositoryException {
+        ObjectNode metadata = objectMapper.createObjectNode().put("Identifier", "id");
+        when(service.getItem(any(ColecticaItemRequest.class))).thenReturn(new ColecticaItem(metadata, null));
+
+        JsonNode body = resources.getItem(new ColecticaItemRequest("fr.insee", "id", "1", "StudyUnit", false, Map.of())).getBody();
+
+        assertThat(body.path("metadata").path("Identifier").asText()).isEqualTo("id");
+        assertThat(body.path("ddi").isMissingNode()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- update the Colectica REST resource to serialize the service response into an explicit JSON payload
- inject the shared ObjectMapper to build the response and adjust the OpenAPI contract accordingly
- add unit coverage to verify the controller exposes metadata and DDI content as JSON, including when the DDI payload is absent

## Testing
- mvn -pl module-domain,module-bauhaus-bo -am -Dtest=ColecticaResourcesTest,ColecticaRestRepositoryTest -Dsurefire.failIfNoSpecifiedTests=false test


------
https://chatgpt.com/codex/tasks/task_e_68e6795e3de483228b6fa7b87946a942